### PR TITLE
Feat/one hot encoding

### DIFF
--- a/nmrcraft/data/dataset.py
+++ b/nmrcraft/data/dataset.py
@@ -143,6 +143,13 @@ def target_label_readabilitizer(readable_labels):
     return human_readable_label_list
 
 
+def target_label_readabilitizer_categorical(target_labels):
+    good_labels = []
+    for label_array in target_labels:
+        good_labels.append(list(label_array))
+    return good_labels
+
+
 # def get_target_labels(target_columns: str, dataset: pd.DataFrame):
 #     # Get unique values for each column
 #     unique_values = [set(dataset[col]) for col in target_columns]
@@ -231,12 +238,13 @@ class DataLoader:
         ]
         self.target_unique_labels = target_unique_labels
         ys = []
+        readable_labels = []
         for i in range(len(target_unique_labels)):
             tmp_encoder = LabelEncoder()
             tmp_encoder.fit(target_unique_labels[i])
             ys.append(tmp_encoder.transform(y_labels[i]))
+            readable_labels.append(tmp_encoder.classes_)
         y = list(zip(*ys))
-
         (
             X_NMR_train,
             X_NMR_test,
@@ -268,7 +276,9 @@ class DataLoader:
             [X_test_NMR_scaled, X_test_structural], axis=1
         )
 
-        return X_train_scaled, X_test_scaled, y_train, y_test
+        # Get the target labels going
+        y_label = target_label_readabilitizer_categorical(readable_labels)
+        return X_train_scaled, X_test_scaled, y_train, y_test, y_label
 
     def split_and_preprocess_one_hot(self):
         """

--- a/nmrcraft/data/dataset.py
+++ b/nmrcraft/data/dataset.py
@@ -108,14 +108,6 @@ def get_target_labels(target_columns: str, dataset: pd.DataFrame):
 #     return result
 
 
-def one_hot_encoding(y):
-    if isinstance((y[0]), int):
-        print("int")
-    if isinstance((y[0]), tuple):
-        max_values = (max(row) for row in zip(*y))
-        print(max_values)
-
-
 class DataLoader:
     def __init__(
         self,

--- a/nmrcraft/data/dataset.py
+++ b/nmrcraft/data/dataset.py
@@ -1,5 +1,7 @@
 """Load and preprocess data."""
 
+import itertools
+
 import pandas as pd
 from datasets import load_dataset
 from sklearn.model_selection import train_test_split
@@ -98,6 +100,14 @@ def get_target_labels(target_columns: str, dataset: pd.DataFrame):
 #     return result
 
 
+def one_hot_encoding(y):
+    if isinstance((y[0]), int):
+        print("int")
+    if isinstance((y[0]), tuple):
+        max_values = (max(row) for row in zip(*y))
+        print(max_values)
+
+
 class DataLoader:
     def __init__(
         self,
@@ -158,12 +168,10 @@ class DataLoader:
         X_train, X_test, y_train, y_test = train_test_split(
             X, y, test_size=self.test_size, random_state=self.random_state
         )
-
         # Make targets 1D if only one is targeted
-        import itertools
-
-        y_train = list(itertools.chain(*y_train))
-        y_test = list(itertools.chain(*y_test))
+        if len(y[0]) == 1:
+            y_train = list(itertools.chain(*y_train))
+            y_test = list(itertools.chain(*y_test))
 
         # Normalize features with no leakage from test set
         X_train_scaled, scaler = self.preprocess_features(X_train)

--- a/nmrcraft/data/dataset.py
+++ b/nmrcraft/data/dataset.py
@@ -122,18 +122,24 @@ def get_target_labels(target_columns: str, dataset: pd.DataFrame):
     return unique_values
 
 
-def target_label_readabilitizer(target_unique_labels):
+def target_label_readabilitizer(readable_labels):
     """
-    function takes the unique target labels and does some stuff so they become human readable for debugging. This function is basically hardcoded and not expandable
+    function takes in the classes from the binarzier and turns them into something human usable.
     """
-    for i in enumerate(target_unique_labels):
-        if target_unique_labels[i] == ["Mo", "W"] or target_unique_labels[
-            i
-        ] == ["W", "Mo"]:
-            target_unique_labels[i] = ["Mo or W"]
-        if target_unique_labels[i] == ["Cl"]:
-            target_unique_labels[i] = ["Cl is always 0"]
-    human_readable_label_list = list(itertools.chain(*target_unique_labels))
+    # Trun that class_ into list
+    human_readable_label_list = list(itertools.chain(*readable_labels))
+    # Handle Binarized metal stuff and make the two columns become a single one
+    for i in enumerate(human_readable_label_list):
+        if (
+            human_readable_label_list[i[0]] == "Mo"
+            and human_readable_label_list[i[0] + 1] == "W"
+        ) or (
+            human_readable_label_list[i[0]] == "W"
+            and human_readable_label_list[i[0] + 1] == "Mo"
+        ):
+            human_readable_label_list[i[0]] = "Mo W"
+            human_readable_label_list.pop(i[0] + 1)
+
     return human_readable_label_list
 
 
@@ -335,7 +341,14 @@ class DataLoader:
         X_test_scaled = np.concatenate(
             [X_test_NMR_scaled, X_test_structural], axis=1
         )
-        print(readable_labels)
-        # print(len(target_label_readabilitizer(one_hot.categories_())))
-        print(y_labels_rotated)
-        return X_train_scaled, X_test_scaled, y_train, y_test
+
+        # Creates the labels that can be used to identify the targets in the binaized y-array
+        good_target_labels = target_label_readabilitizer(readable_labels)
+
+        return (
+            X_train_scaled,
+            X_test_scaled,
+            y_train,
+            y_test,
+            good_target_labels,
+        )

--- a/nmrcraft/data/dataset.py
+++ b/nmrcraft/data/dataset.py
@@ -122,6 +122,21 @@ def get_target_labels(target_columns: str, dataset: pd.DataFrame):
     return unique_values
 
 
+def target_label_readabilitizer(target_unique_labels):
+    """
+    function takes the unique target labels and does some stuff so they become human readable for debugging. This function is basically hardcoded and not expandable
+    """
+    for i in enumerate(target_unique_labels):
+        if target_unique_labels[i] == ["Mo", "W"] or target_unique_labels[
+            i
+        ] == ["W", "Mo"]:
+            target_unique_labels[i] = ["Mo or W"]
+        if target_unique_labels[i] == ["Cl"]:
+            target_unique_labels[i] = ["Cl is always 0"]
+    human_readable_label_list = list(itertools.chain(*target_unique_labels))
+    return human_readable_label_list
+
+
 # def get_target_labels(target_columns: str, dataset: pd.DataFrame):
 #     # Get unique values for each column
 #     unique_values = [set(dataset[col]) for col in target_columns]
@@ -266,8 +281,11 @@ class DataLoader:
         ]
         self.target_unique_labels = target_unique_labels
         ys = []
+        readable_labels = []
         for i in range(len(target_unique_labels)):
-            ys.append(LabelBinarizer().fit_transform(y_labels[i]))
+            LBiner = LabelBinarizer()
+            ys.append(LBiner.fit_transform(y_labels[i]))
+            readable_labels.append(LBiner.classes_)
         y = np.concatenate(list(ys), axis=1)
 
         # Get NMR and structural Features, one-hot-encode and combine
@@ -317,5 +335,7 @@ class DataLoader:
         X_test_scaled = np.concatenate(
             [X_test_NMR_scaled, X_test_structural], axis=1
         )
-
+        print(readable_labels)
+        # print(len(target_label_readabilitizer(one_hot.categories_())))
+        print(y_labels_rotated)
         return X_train_scaled, X_test_scaled, y_train, y_test

--- a/scripts/training/train_metal.py
+++ b/scripts/training/train_metal.py
@@ -46,7 +46,7 @@ def main(dataset_size, target, model_name):
         )
 
         # Load and preprocess data
-        X_train, X_test, y_train, y_test = data_loader.load_data()
+        X_train, X_test, y_train, y_test, y_labels = data_loader.load_data()
 
         tuner = HyperparameterTuner(model_name, config)
         best_params, _ = tuner.tune(X_train, y_train, X_test, y_test)


### PR DESCRIPTION
# Features:
## One-Hot encoding of the data features
The features of what ligand and what metal are on the complex should be binarized while we keep the NMR info as numbers.
## Binarization of Targets
This PR should add the ability to the dataloader to give out binarized target data.

# Implementation
My current approach is to have a second split and preprocess function because I felt like the two functions would be different enough to justify having two separate ones, but they do share a bit of code. I have no clue how inheritance works in python and if you even can do that stuff with functions or only with classes. If anyone wants to propose a radically different approach to solving this, feel free to suggest it.

# Target example:
![image](https://github.com/mlederbauer/NMRcraft/assets/115071397/d4967ab4-dd3f-4297-899f-77af69b2a8fd)

# New Bugs
A new bug is introduced where you cannot have _all_ the structural features as targets, as that would lead to the X array be empty and the program throwing an Error. I don't think this is something that needs to be quickly fixed, as I believe we will always be leaving out at least one structural feature for the X-array.
