### PR TITLE
One hot encoding and categorical encoding separated in dataloader. Structural featurs implemented.

### DIFF
--- a/nmrcraft/data/dataset.py
+++ b/nmrcraft/data/dataset.py
@@ -150,14 +150,6 @@ def target_label_readabilitizer_categorical(target_labels):
     return good_labels
 
 
-# def get_target_labels(target_columns: str, dataset: pd.DataFrame):
-#     # Get unique values for each column
-#     unique_values = [set(dataset[col]) for col in target_columns]
-#     # Convert the list of sets to a list of lists
-#     result = [[i for i in s] for s in unique_values]
-#     return result
-
-
 class DataLoader:
     def __init__(
         self,


### PR DESCRIPTION
# Readdition of One-hot-encoding
Reopening of #35 

# Features:
## One-Hot encoding of the data features
The features of what ligand and what metal are on the complex should be binarized while we keep the NMR info as numbers.
## Binarization of Targets
This PR should add the ability to the dataloader to give out binarized target data.

# Implementation
My current approach is to have a second split and preprocess function because I felt like the two functions would be different enough to justify having two separate ones, but they do share a bit of code. I have no clue how inheritance works in python and if you even can do that stuff with functions or only with classes. If anyone wants to propose a radically different approach to solving this, feel free to suggest it.

# Target example:
![image](https://github.com/mlederbauer/NMRcraft/assets/115071397/d4967ab4-dd3f-4297-899f-77af69b2a8fd)

# New Bugs
A new bug is introduced where you cannot have _all_ the structural features as targets, as that would lead to the X array be empty and the program throwing an Error. I don't think this is something that needs to be quickly fixed, as I believe we will always be leaving out at least one structural feature for the X-array.
