### PR TITLE
Fix: gave right var as class label for confusion matrix

### DIFF
--- a/scripts/training/train_metal.py
+++ b/scripts/training/train_metal.py
@@ -76,7 +76,7 @@ def main(dataset_size, target, model_name):
         title = r"Confusion matrix, TODO add LaTeX symbols"
         plot_confusion_matrix(
             cm,
-            classes=data_loader.target_unique_labels,
+            classes=y_labels,
             title=title,
             path=cm_path,
         )


### PR DESCRIPTION
Was looking into the training script to get how it works and found this mistake. 
**Please do not access the variables in the dataloader directly and only use that for which there is a function.**
This label list for example is sorted based on the input but the y_test and y_train you get as output are sorted based on whatever the binarizer does, so you also get the labels from the binarizer.