### PR TITLE
fix: sample training data after splitting

### DIFF
--- a/nmrcraft/data/dataloader.py
+++ b/nmrcraft/data/dataloader.py
@@ -72,7 +72,6 @@ class DataLoader:
             Preprocessed data (pandas.DataFrame): The preprocessed dataset.
         """
         self.dataset = filename_to_ligands(self.dataset)
-        self.dataset = self.dataset.sample(frac=self.dataset_size)
         self.choose_geometry()
         return self.split_and_preprocess()
 
@@ -192,6 +191,19 @@ class DataLoader:
             test_size=self.test_size,
             random_state=self.random_state,
         )
+
+        # Further sample the training data to reduce its size
+        train_size = int(len(y_train) * self.dataset_size)
+        if train_size < 1:
+            train_size = 1  # Ensure at least one sample
+
+        indices = np.arange(len(y_train))
+        np.random.shuffle(indices)
+        indices = indices[:train_size]
+
+        X_train_NMR = X_train_NMR[indices]
+        X_train_Structural = X_train_Structural[indices]
+        y_train = y_train[indices]
 
         # Scale numerical features (the NMR tensor)
         scaler = StandardScaler()


### PR DESCRIPTION
![image](https://github.com/mlederbauer/NMRcraft/assets/98785759/48ffb42d-852c-43f9-a6bc-89fa78e4fcc5)


This now uniformly samples training data _after_ the train-test-split, meaning that we always have a constant test size of 3434 complexes

Only issue I would see here is that the current code does not consider the case where there is a ligand in the test set that is not part of the train set. That causesz the model to "never see such a ligand" and thus decrease performance significantly

For this, we would however need to build our own "iterative stratified sapling" which is rather a hassle to implement. We could just include it in the conclusion of our project for now!

https://stackoverflow.com/questions/45516424/sklearn-train-test-split-on-pandas-stratify-by-multiple-columns