### PR TITLE
Fixed that no nmr_only = Trues were created

### DIFF
--- a/nmrcraft/utils/general.py
+++ b/nmrcraft/utils/general.py
@@ -27,3 +27,14 @@ def add_rows_metrics(
         ]
         unified_metrics.loc[len(unified_metrics)] = new_row
     return unified_metrics
+
+
+def str2bool(value: str) -> bool:
+    """Function converts a string to boolean in a human expected way.
+
+    Args (str):
+      <value> as a string for example 'True' or 'true' or 't'
+    Returns (bool):
+      bool corresponding to if the <value> was true or false
+    """
+    return value.lower() in ("yes", "true", "t", "1")

--- a/scripts/training/multi_targets.py
+++ b/scripts/training/multi_targets.py
@@ -12,7 +12,7 @@ from nmrcraft.evaluation import evaluation
 from nmrcraft.models.model_configs import model_configs
 from nmrcraft.models.models import load_model
 from nmrcraft.training.hyperparameter_tune import HyperparameterTuner
-from nmrcraft.utils.general import add_rows_metrics
+from nmrcraft.utils.general import add_rows_metrics, str2bool
 
 # Setup MLflow
 mlflow.set_experiment("Final_results")
@@ -36,8 +36,8 @@ parser.add_argument(
 )
 parser.add_argument(
     "--include_structural",
-    type=bool,
-    default=False,
+    type=str2bool,
+    default="False",
     help="Handles if structural features will be included or only nmr tensors are used.",
 )
 parser.add_argument(

--- a/scripts/training/one_target.py
+++ b/scripts/training/one_target.py
@@ -12,7 +12,7 @@ from nmrcraft.evaluation import evaluation
 from nmrcraft.models.model_configs import model_configs
 from nmrcraft.models.models import load_model
 from nmrcraft.training.hyperparameter_tune import HyperparameterTuner
-from nmrcraft.utils.general import add_rows_metrics
+from nmrcraft.utils.general import add_rows_metrics, str2bool
 
 # Setup MLflow
 mlflow.set_experiment("Final_Results")
@@ -36,8 +36,8 @@ parser.add_argument(
 )
 parser.add_argument(
     "--include_structural",
-    type=bool,
-    default=False,
+    type=str2bool,
+    default="False",
     help="Handles if structural features will be included or only nmr tensors are used.",
 )
 parser.add_argument(
@@ -161,7 +161,6 @@ if __name__ == "__main__":
     # Add arguments
     args = parser.parse_args()
     args.target = [args.target]  # FIXME
-
     unified_metrics = main(args)
 
     # save all the results


### PR DESCRIPTION
There was some logic mismatch with the internal booleans and the strings passed to the function. Basically, all the full strings were evaluated to true, even if the string was "false"